### PR TITLE
fix: harden async result and executor timers

### DIFF
--- a/examples/client_loopback.cpp
+++ b/examples/client_loopback.cpp
@@ -1,9 +1,8 @@
 // Copyright (c) 2025 [caomengxuan666]
 //
 // Compatibility example: exercises concrete client/server loopback plumbing.
-// The server is built via ServerPeer::builder(); the deprecated server()
-// accessor exposes the underlying Server for the client::Transport loopback
-// adapter.
+// The server is built via ServerPeer::builder(); the client::Transport
+// loopback adapter dispatches through ServerPeer::handle_request().
 
 #include <cstdint>
 #include <iostream>
@@ -29,11 +28,12 @@ void require(bool condition, std::string_view message) {
 
 class LoopbackTransport final : public mcp::client::Transport {
  public:
-  explicit LoopbackTransport(mcp::server::Server& server) : server_(server) {}
+  explicit LoopbackTransport(mcp::ServerPeer& server_peer)
+      : server_peer_(server_peer) {}
 
   mcp::core::Result<mcp::protocol::JsonRpcResponse> send(
       const mcp::protocol::JsonRpcRequest& request) override {
-    return server_.handle_request(request, context_);
+    return server_peer_.handle_request(request, context_);
   }
 
   mcp::core::Result<mcp::core::Unit> send_notification(
@@ -47,7 +47,7 @@ class LoopbackTransport final : public mcp::client::Transport {
   }
 
  private:
-  mcp::server::Server& server_;
+  mcp::ServerPeer& server_peer_;
   mcp::server::SessionContext context_{
       .session_id = "example",
       .remote_address = "127.0.0.1",
@@ -155,10 +155,7 @@ int main() {
             .build();
     require(server_peer.has_value(), "failed to build example server");
 
-    // The loopback transport needs the underlying Server object.
-    auto& server = server_peer->server();
-
-    auto transport = std::make_unique<LoopbackTransport>(server);
+    auto transport = std::make_unique<LoopbackTransport>(*server_peer);
     auto* transport_ptr = transport.get();
     mcp::ClientPeer peer(mcp::client::Client(std::move(transport)));
 

--- a/sdk/core/include/cxxmcp/core/async_result.hpp
+++ b/sdk/core/include/cxxmcp/core/async_result.hpp
@@ -136,25 +136,28 @@ class AsyncResult {
       -> std::shared_ptr<AsyncResult<std::invoke_result_t<F, ResultType>>> {
     using R = std::invoke_result_t<F, ResultType>;
     auto next = std::make_shared<AsyncResult<R>>();
+    std::optional<ResultType> ready_value;
     {
       std::lock_guard<std::mutex> lock(mutex_);
       if (value_.has_value()) {
-        // Already resolved -- fire immediately
-        try {
-          next->set_value(callback(*value_));
-        } catch (...) {
-          next->set_exception(std::current_exception());
-        }
-        return next;
+        ready_value = *value_;
+      } else {
+        continuations_.emplace_back(
+            [next, cb = std::forward<F>(callback)](ResultType result) mutable {
+              try {
+                next->set_value(cb(std::move(result)));
+              } catch (...) {
+                next->set_exception(std::current_exception());
+              }
+            });
       }
-      continuations_.emplace_back(
-          [next, cb = std::forward<F>(callback)](ResultType result) mutable {
-            try {
-              next->set_value(cb(std::move(result)));
-            } catch (...) {
-              next->set_exception(std::current_exception());
-            }
-          });
+    }
+    if (ready_value.has_value()) {
+      try {
+        next->set_value(callback(std::move(*ready_value)));
+      } catch (...) {
+        next->set_exception(std::current_exception());
+      }
     }
     return next;
   }
@@ -278,24 +281,28 @@ class AsyncResult<void> {
       -> std::shared_ptr<AsyncResult<std::invoke_result_t<F, ResultType>>> {
     using R = std::invoke_result_t<F, ResultType>;
     auto next = std::make_shared<AsyncResult<R>>();
+    std::optional<ResultType> ready_value;
     {
       std::lock_guard<std::mutex> lock(mutex_);
       if (value_.has_value()) {
-        try {
-          next->set_value(callback(*value_));
-        } catch (...) {
-          next->set_exception(std::current_exception());
-        }
-        return next;
+        ready_value = *value_;
+      } else {
+        continuations_.emplace_back(
+            [next, cb = std::forward<F>(callback)](ResultType result) mutable {
+              try {
+                next->set_value(cb(std::move(result)));
+              } catch (...) {
+                next->set_exception(std::current_exception());
+              }
+            });
       }
-      continuations_.emplace_back(
-          [next, cb = std::forward<F>(callback)](ResultType result) mutable {
-            try {
-              next->set_value(cb(std::move(result)));
-            } catch (...) {
-              next->set_exception(std::current_exception());
-            }
-          });
+    }
+    if (ready_value.has_value()) {
+      try {
+        next->set_value(callback(std::move(*ready_value)));
+      } catch (...) {
+        next->set_exception(std::current_exception());
+      }
     }
     return next;
   }

--- a/sdk/core/include/cxxmcp/core/executor.hpp
+++ b/sdk/core/include/cxxmcp/core/executor.hpp
@@ -148,10 +148,11 @@ class Executor {
     auto entry = std::make_shared<TimerEntry>();
     entry->when = when;
     entry->task = std::move(task);
-    entry->id = next_timer_id_++;
+    entry->priority = static_cast<int>(prio);
     TimerHandle handle(entry);
     {
       std::lock_guard<std::mutex> lock(timer_mutex_);
+      entry->id = next_timer_id_++;
       timers_.push(entry);
     }
     timer_cv_.notify_one();
@@ -296,7 +297,8 @@ class Executor {
       }
       // Dispatch the timer task into the appropriate priority queue
       if (next && next->task) {
-        (void)post(std::move(next->task), TaskPriority::DEFAULT);
+        (void)post(std::move(next->task),
+                   static_cast<TaskPriority>(next->priority));
       }
     }
   }

--- a/sdk/core/include/cxxmcp/core/timer_handle.hpp
+++ b/sdk/core/include/cxxmcp/core/timer_handle.hpp
@@ -16,6 +16,7 @@ struct TimerEntry {
   std::function<void()> task;
   std::atomic<bool> cancelled{false};
   std::uint64_t id = 0;
+  int priority = 1;
 };
 
 /// @brief Handle to a scheduled timer that can be cancelled before it fires.

--- a/tests/fixtures/process_stdio_child.cpp
+++ b/tests/fixtures/process_stdio_child.cpp
@@ -49,6 +49,23 @@ std::optional<mcp::protocol::JsonRpcResponse> read_response() {
   return *parsed;
 }
 
+std::string get_process_env_or_empty(std::string_view key) {
+  const std::string key_string(key);
+#ifdef _WIN32
+  char* value = nullptr;
+  std::size_t size = 0;
+  if (_dupenv_s(&value, &size, key_string.c_str()) != 0 || value == nullptr) {
+    return {};
+  }
+  std::string result(value);
+  std::free(value);
+  return result;
+#else
+  const char* value = std::getenv(key_string.c_str());
+  return value == nullptr ? std::string{} : std::string(value);
+#endif
+}
+
 void write_error(const mcp::protocol::JsonRpcRequest& request,
                  mcp::protocol::ErrorCode code, std::string message) {
   write_response(mcp::protocol::make_error_response(
@@ -306,13 +323,13 @@ void handle_request(const mcp::protocol::JsonRpcRequest& request) {
   }
 
   if (request.method == "custom/options") {
-    const char* env_value = std::getenv("CXXMCP_PROCESS_TEST_ENV");
     write_response(mcp::protocol::make_response(
-        request.id, Json{
-                        {"arg", g_observed_arg},
-                        {"env", env_value == nullptr ? "" : env_value},
-                        {"cwd", std::filesystem::current_path().string()},
-                    }));
+        request.id,
+        Json{
+            {"arg", g_observed_arg},
+            {"env", get_process_env_or_empty("CXXMCP_PROCESS_TEST_ENV")},
+            {"cwd", std::filesystem::current_path().string()},
+        }));
     return;
   }
 

--- a/tests/sdk/test_sdk.cpp
+++ b/tests/sdk/test_sdk.cpp
@@ -17,6 +17,7 @@
 #include <variant>
 #include <vector>
 
+#include "cxxmcp/core/async_result.hpp"
 #include "cxxmcp/core/executor.hpp"
 #include "cxxmcp/sdk.hpp"
 
@@ -3309,6 +3310,105 @@ void test_executor_reports_task_exceptions() {
           "executor exception handler message mismatch");
 }
 
+void test_async_result_ready_then_runs_callback_outside_lock() {
+  auto result = std::make_shared<mcp::core::AsyncResult<int>>();
+  result->set_value(42);
+
+  auto next = result->then([&](mcp::core::Result<int> value) {
+    require(value.has_value() && *value == 42,
+            "ready async result value should be forwarded");
+    return result->ready() ? 7 : 0;
+  });
+
+  const auto chained = next->wait_for(std::chrono::seconds(1));
+  require(chained.has_value(), "ready async continuation should not fail");
+  require(*chained == 7, "ready async continuation result mismatch");
+}
+
+void test_executor_timer_preserves_task_priority() {
+  mcp::core::Executor executor(mcp::core::Executor::Options{1, 16, {}});
+
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool release_worker = false;
+  std::vector<std::string> order;
+
+  const auto blocker = executor.post(
+      [&] {
+        std::unique_lock<std::mutex> lock(mutex);
+        cv.wait(lock, [&] { return release_worker; });
+      },
+      mcp::core::TaskPriority::IO_BOUND);
+  require(blocker.has_value(), "blocking executor task should enqueue");
+
+  auto timer = executor.post_after(
+      std::chrono::milliseconds(10),
+      [&] {
+        std::lock_guard<std::mutex> lock(mutex);
+        order.push_back("timer-background");
+      },
+      mcp::core::TaskPriority::BACKGROUND);
+  require(timer.valid(), "delayed executor task should return timer handle");
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  const auto queued = executor.post(
+      [&] {
+        std::lock_guard<std::mutex> lock(mutex);
+        order.push_back("plain-default");
+      },
+      mcp::core::TaskPriority::DEFAULT);
+  require(queued.has_value(), "default executor task should enqueue");
+
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    release_worker = true;
+  }
+  cv.notify_all();
+  executor.shutdown();
+
+  require(order.size() == 2, "executor should drain both queued tasks");
+  require(order[0] == "plain-default" && order[1] == "timer-background",
+          "delayed background task should keep background priority");
+}
+
+void test_executor_timer_scheduling_is_thread_safe() {
+  constexpr int kPosterCount = 4;
+  constexpr int kTimersPerPoster = 25;
+  constexpr int kExpectedTimers = kPosterCount * kTimersPerPoster;
+
+  mcp::core::Executor executor(mcp::core::Executor::Options{4, 256, {}});
+  std::atomic<int> completed{0};
+  std::vector<std::thread> posters;
+  posters.reserve(kPosterCount);
+
+  for (int poster = 0; poster < kPosterCount; ++poster) {
+    posters.emplace_back([&] {
+      for (int i = 0; i < kTimersPerPoster; ++i) {
+        auto timer = executor.post_after(
+            std::chrono::milliseconds(1),
+            [&] { completed.fetch_add(1, std::memory_order_relaxed); },
+            mcp::core::TaskPriority::BACKGROUND);
+        require(timer.valid(), "concurrent delayed task should return handle");
+      }
+    });
+  }
+
+  for (auto& poster : posters) {
+    poster.join();
+  }
+
+  for (int i = 0;
+       i < 100 && completed.load(std::memory_order_relaxed) < kExpectedTimers;
+       ++i) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  executor.shutdown();
+
+  require(completed.load(std::memory_order_relaxed) == kExpectedTimers,
+          "all concurrently scheduled timers should run");
+}
+
 void test_server_routers_apply_to_builders() {
   int router_changes = 0;
   mcp::server::ToolRouter base_tools;
@@ -3708,6 +3808,9 @@ int main() {
     test_registries_invoke_handlers_outside_internal_locks();
     test_executor_rejects_empty_task();
     test_executor_reports_task_exceptions();
+    test_async_result_ready_then_runs_callback_outside_lock();
+    test_executor_timer_preserves_task_priority();
+    test_executor_timer_scheduling_is_thread_safe();
     test_server_routers_apply_to_builders();
     test_server_routers_emit_bound_list_changed_notifications();
     test_public_error_helpers_assign_stable_categories();

--- a/tests/transport/test_process_stdio_transport.cpp
+++ b/tests/transport/test_process_stdio_transport.cpp
@@ -7,6 +7,7 @@
 #include <filesystem>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -64,6 +65,26 @@ std::filesystem::path rust_stdio_child_executable() {
   return binary;
 }
 
+std::optional<std::string> get_process_env(std::string_view key) {
+  const std::string key_string(key);
+#ifdef _WIN32
+  char* value = nullptr;
+  std::size_t size = 0;
+  if (_dupenv_s(&value, &size, key_string.c_str()) != 0 || value == nullptr) {
+    return std::nullopt;
+  }
+  std::string result(value);
+  std::free(value);
+  return result;
+#else
+  const char* value = std::getenv(key_string.c_str());
+  if (value == nullptr) {
+    return std::nullopt;
+  }
+  return std::string(value);
+#endif
+}
+
 std::unordered_map<std::string, std::string> rust_cargo_env() {
   const auto target_dir = std::filesystem::temp_directory_path() /
                           "mcp-rust-process-stdio-child-target";
@@ -71,13 +92,13 @@ std::unordered_map<std::string, std::string> rust_cargo_env() {
       {"CARGO_TARGET_DIR", target_dir.string()},
   };
 
-  if (const char* proxy = std::getenv("CXXMCP_CARGO_PROXY");
-      proxy != nullptr && std::string_view(proxy).size() > 0) {
-    env["CARGO_HTTP_PROXY"] = proxy;
-    env["CARGO_HTTPS_PROXY"] = proxy;
-    env["HTTP_PROXY"] = proxy;
-    env["HTTPS_PROXY"] = proxy;
-    env["ALL_PROXY"] = proxy;
+  if (const auto proxy = get_process_env("CXXMCP_CARGO_PROXY");
+      proxy.has_value() && !proxy->empty()) {
+    env["CARGO_HTTP_PROXY"] = *proxy;
+    env["CARGO_HTTPS_PROXY"] = *proxy;
+    env["HTTP_PROXY"] = *proxy;
+    env["HTTPS_PROXY"] = *proxy;
+    env["ALL_PROXY"] = *proxy;
   }
   return env;
 }
@@ -101,8 +122,8 @@ void prepare_rust_stdio_child_build_env() {
 void build_rust_stdio_child() {
   prepare_rust_stdio_child_build_env();
   std::string command = "cargo build ";
-  if (const char* offline = std::getenv("CXXMCP_RUST_FIXTURE_OFFLINE");
-      offline != nullptr && std::string_view(offline) == "1") {
+  if (const auto offline = get_process_env("CXXMCP_RUST_FIXTURE_OFFLINE");
+      offline.has_value() && *offline == "1") {
     command += "--offline ";
   }
   command += "--manifest-path \"" + rust_stdio_child_manifest().string() + "\"";


### PR DESCRIPTION
## Summary
- run ready `AsyncResult::then()` callbacks outside the result mutex
- preserve delayed executor task priority and serialize timer id assignment
- remove deprecated/example warning paths for loopback and Windows env reads

## Tests
- `pwsh -NoProfile -File scripts\format.ps1 -Check`
- `cmake --build --preset tests --target mcp_sdk_tests mcp_process_stdio_transport_tests`
- `ctest --test-dir out/build/tests -R "^(sdk|process_stdio_transport)$" --output-on-failure --timeout 240`
- `cmake --build --preset examples --target mcp_example_client_loopback`
- `ctest --test-dir out/build/examples -R "^example_client_loopback$" --output-on-failure`