### PR TITLE
fix: normalize SDK source archive hash inputs

### DIFF
--- a/docs/package_consumption.md
+++ b/docs/package_consumption.md
@@ -137,7 +137,7 @@ include(FetchContent)
 FetchContent_Declare(
     cxxmcp
     URL https://github.com/caomengxuan666/cxxmcp/releases/download/v1.1.3/cxxmcp-sdk-source-v1.1.3.tar.gz
-    URL_HASH SHA256=ad4edc8333c481e3ccbe5d4fb9cfddaca664ceb68bce169e25c0f07397e6dfb4
+    URL_HASH SHA256=b4159fd9dff90482aac69dfe9a4e6491f71045c0d39fc4f8217e8e7d9d480eec
 )
 
 set(CXXMCP_BUILD_SDK ON CACHE BOOL "" FORCE)
@@ -177,7 +177,7 @@ set(CXXMCP_BUILD_DOCS OFF CACHE BOOL "" FORCE)
 CPMAddPackage(
     NAME cxxmcp
     URL https://github.com/caomengxuan666/cxxmcp/releases/download/v1.1.3/cxxmcp-sdk-source-v1.1.3.tar.gz
-    URL_HASH SHA256=ad4edc8333c481e3ccbe5d4fb9cfddaca664ceb68bce169e25c0f07397e6dfb4
+    URL_HASH SHA256=b4159fd9dff90482aac69dfe9a4e6491f71045c0d39fc4f8217e8e7d9d480eec
 )
 
 add_executable(my_client main.cpp)

--- a/docs/package_consumption_zh.md
+++ b/docs/package_consumption_zh.md
@@ -121,7 +121,7 @@ include(FetchContent)
 FetchContent_Declare(
     cxxmcp
     URL https://github.com/caomengxuan666/cxxmcp/releases/download/v1.1.3/cxxmcp-sdk-source-v1.1.3.tar.gz
-    URL_HASH SHA256=ad4edc8333c481e3ccbe5d4fb9cfddaca664ceb68bce169e25c0f07397e6dfb4
+    URL_HASH SHA256=b4159fd9dff90482aac69dfe9a4e6491f71045c0d39fc4f8217e8e7d9d480eec
 )
 
 set(CXXMCP_BUILD_SDK ON CACHE BOOL "" FORCE)
@@ -158,7 +158,7 @@ set(CXXMCP_BUILD_DOCS OFF CACHE BOOL "" FORCE)
 CPMAddPackage(
     NAME cxxmcp
     URL https://github.com/caomengxuan666/cxxmcp/releases/download/v1.1.3/cxxmcp-sdk-source-v1.1.3.tar.gz
-    URL_HASH SHA256=ad4edc8333c481e3ccbe5d4fb9cfddaca664ceb68bce169e25c0f07397e6dfb4
+    URL_HASH SHA256=b4159fd9dff90482aac69dfe9a4e6491f71045c0d39fc4f8217e8e7d9d480eec
 )
 
 add_executable(my_client main.cpp)

--- a/docs/pages/cookbook.html
+++ b/docs/pages/cookbook.html
@@ -315,7 +315,7 @@ target_link_libraries(server PRIVATE cxxmcp::server)</code></pre>
           <pre><code class="language-cmake">include(FetchContent)
 FetchContent_Declare(cxxmcp
     URL https://github.com/caomengxuan666/cxxmcp/releases/download/v1.1.3/cxxmcp-sdk-source-v1.1.3.tar.gz
-    URL_HASH SHA256=ad4edc8333c481e3ccbe5d4fb9cfddaca664ceb68bce169e25c0f07397e6dfb4
+    URL_HASH SHA256=b4159fd9dff90482aac69dfe9a4e6491f71045c0d39fc4f8217e8e7d9d480eec
 )
 FetchContent_MakeAvailable(cxxmcp)
 

--- a/packaging/xmake/packages/c/cxxmcp/xmake.lua
+++ b/packaging/xmake/packages/c/cxxmcp/xmake.lua
@@ -4,7 +4,7 @@ package("cxxmcp")
     set_license("MIT")
 
     add_urls("https://github.com/caomengxuan666/cxxmcp/releases/download/$(version)/cxxmcp-sdk-source-$(version).tar.gz")
-    add_versions("v1.1.3", "ad4edc8333c481e3ccbe5d4fb9cfddaca664ceb68bce169e25c0f07397e6dfb4")
+    add_versions("v1.1.3", "b4159fd9dff90482aac69dfe9a4e6491f71045c0d39fc4f8217e8e7d9d480eec")
     add_configs("http", {description = "Build HTTP/SSE transport (requires cpp-httplib).", default = false, type = "boolean"})
     add_configs("auth", {description = "Build the optional OAuth 2.1 / DPoP auth scaffold target.", default = false, type = "boolean"})
 

--- a/scripts/create_sdk_source_archive.py
+++ b/scripts/create_sdk_source_archive.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import io
 import gzip
 import hashlib
 from pathlib import Path
@@ -90,6 +91,7 @@ def create_sdk_source_archive(root: Path, tag: str, output: Path) -> Path:
                 for path in included_files(root):
                     relative = relative_name(path, root)
                     arcname = f"{prefix}/{relative}"
+                    data = archive_file_bytes(path)
                     info = archive.gettarinfo(str(path), arcname)
                     info.uid = 0
                     info.gid = 0
@@ -97,9 +99,17 @@ def create_sdk_source_archive(root: Path, tag: str, output: Path) -> Path:
                     info.gname = ""
                     info.mtime = 0
                     info.mode = 0o644
-                    with path.open("rb") as handle:
+                    info.size = len(data)
+                    with io.BytesIO(data) as handle:
                         archive.addfile(info, handle)
     return output
+
+
+def archive_file_bytes(path: Path) -> bytes:
+    data = path.read_bytes()
+    if b"\0" in data:
+        return data
+    return data.replace(b"\r\n", b"\n")
 
 
 def sha256(path: Path) -> str:


### PR DESCRIPTION
Normalize text file line endings while creating the deterministic SDK source archive so Windows release preparation computes the same SHA256 as the Linux release workflow.

This replaces the incorrect v1.1.3 package-consumption hash after deleting the bad v1.1.3 release/tag.

Verification:
- `python -B scripts\prepare_release.py 1.1.3 --skip-checks`
- `python -B scripts\check_package_recipe_sync.py --source .`
- `python -B scripts\check_release_evidence.py --source .`
- `python -B scripts\selftest_release_artifacts.py`
- `pwsh -NoProfile -File scripts\format.ps1 -Check`