### PR TITLE
fix: exclude Python bytecode from SDK source archive

### DIFF
--- a/docs/package_consumption.md
+++ b/docs/package_consumption.md
@@ -137,7 +137,7 @@ include(FetchContent)
 FetchContent_Declare(
     cxxmcp
     URL https://github.com/caomengxuan666/cxxmcp/releases/download/v1.1.3/cxxmcp-sdk-source-v1.1.3.tar.gz
-    URL_HASH SHA256=b4159fd9dff90482aac69dfe9a4e6491f71045c0d39fc4f8217e8e7d9d480eec
+    URL_HASH SHA256=ebf256c24e806301b65749ff22960b717aef46bba625c5d8a7edf9e237ccf936
 )
 
 set(CXXMCP_BUILD_SDK ON CACHE BOOL "" FORCE)
@@ -177,7 +177,7 @@ set(CXXMCP_BUILD_DOCS OFF CACHE BOOL "" FORCE)
 CPMAddPackage(
     NAME cxxmcp
     URL https://github.com/caomengxuan666/cxxmcp/releases/download/v1.1.3/cxxmcp-sdk-source-v1.1.3.tar.gz
-    URL_HASH SHA256=b4159fd9dff90482aac69dfe9a4e6491f71045c0d39fc4f8217e8e7d9d480eec
+    URL_HASH SHA256=ebf256c24e806301b65749ff22960b717aef46bba625c5d8a7edf9e237ccf936
 )
 
 add_executable(my_client main.cpp)

--- a/docs/package_consumption_zh.md
+++ b/docs/package_consumption_zh.md
@@ -121,7 +121,7 @@ include(FetchContent)
 FetchContent_Declare(
     cxxmcp
     URL https://github.com/caomengxuan666/cxxmcp/releases/download/v1.1.3/cxxmcp-sdk-source-v1.1.3.tar.gz
-    URL_HASH SHA256=b4159fd9dff90482aac69dfe9a4e6491f71045c0d39fc4f8217e8e7d9d480eec
+    URL_HASH SHA256=ebf256c24e806301b65749ff22960b717aef46bba625c5d8a7edf9e237ccf936
 )
 
 set(CXXMCP_BUILD_SDK ON CACHE BOOL "" FORCE)
@@ -158,7 +158,7 @@ set(CXXMCP_BUILD_DOCS OFF CACHE BOOL "" FORCE)
 CPMAddPackage(
     NAME cxxmcp
     URL https://github.com/caomengxuan666/cxxmcp/releases/download/v1.1.3/cxxmcp-sdk-source-v1.1.3.tar.gz
-    URL_HASH SHA256=b4159fd9dff90482aac69dfe9a4e6491f71045c0d39fc4f8217e8e7d9d480eec
+    URL_HASH SHA256=ebf256c24e806301b65749ff22960b717aef46bba625c5d8a7edf9e237ccf936
 )
 
 add_executable(my_client main.cpp)

--- a/docs/pages/cookbook.html
+++ b/docs/pages/cookbook.html
@@ -315,7 +315,7 @@ target_link_libraries(server PRIVATE cxxmcp::server)</code></pre>
           <pre><code class="language-cmake">include(FetchContent)
 FetchContent_Declare(cxxmcp
     URL https://github.com/caomengxuan666/cxxmcp/releases/download/v1.1.3/cxxmcp-sdk-source-v1.1.3.tar.gz
-    URL_HASH SHA256=b4159fd9dff90482aac69dfe9a4e6491f71045c0d39fc4f8217e8e7d9d480eec
+    URL_HASH SHA256=ebf256c24e806301b65749ff22960b717aef46bba625c5d8a7edf9e237ccf936
 )
 FetchContent_MakeAvailable(cxxmcp)
 

--- a/packaging/xmake/packages/c/cxxmcp/xmake.lua
+++ b/packaging/xmake/packages/c/cxxmcp/xmake.lua
@@ -4,7 +4,7 @@ package("cxxmcp")
     set_license("MIT")
 
     add_urls("https://github.com/caomengxuan666/cxxmcp/releases/download/$(version)/cxxmcp-sdk-source-$(version).tar.gz")
-    add_versions("v1.1.3", "b4159fd9dff90482aac69dfe9a4e6491f71045c0d39fc4f8217e8e7d9d480eec")
+    add_versions("v1.1.3", "ebf256c24e806301b65749ff22960b717aef46bba625c5d8a7edf9e237ccf936")
     add_configs("http", {description = "Build HTTP/SSE transport (requires cpp-httplib).", default = false, type = "boolean"})
     add_configs("auth", {description = "Build the optional OAuth 2.1 / DPoP auth scaffold target.", default = false, type = "boolean"})
 

--- a/scripts/create_sdk_source_archive.py
+++ b/scripts/create_sdk_source_archive.py
@@ -74,6 +74,8 @@ def included_files(root: Path) -> list[Path]:
             relative = relative_name(child, root)
             if relative in SDK_SOURCE_EXCLUDES:
                 continue
+            if "__pycache__/" in relative or relative.endswith(".pyc"):
+                continue
             if relative.startswith("docs/doxygen/"):
                 continue
             files.append(child)


### PR DESCRIPTION
Exclude Python bytecode caches from the deterministic SDK source archive and refresh the v1.1.3 package-consumption hash.

The previous failed v1.1.3 release/tag has been deleted. This keeps local Windows release preparation aligned with the Linux release workflow even when local `scripts/__pycache__` files exist.

Verification:
- `python -B scripts\prepare_release.py 1.1.3 --skip-checks`
- `python -B scripts\check_package_recipe_sync.py --source .`
- `python -B scripts\check_release_evidence.py --source .`
- `pwsh -NoProfile -File scripts\format.ps1 -Check`