### PR TITLE
Fix streamable HTTP CORS preflight

### DIFF
--- a/sdk/server/src/http_transport.cpp
+++ b/sdk/server/src/http_transport.cpp
@@ -289,6 +289,27 @@ core::Result<core::Unit> validate_origin_header(
   return core::Unit{};
 }
 
+void set_cors_preflight_headers(
+    const httplib::Request& request, httplib::Response& response,
+    const std::vector<std::string>& allowed_origins) {
+  if (request.has_header("Origin")) {
+    const auto origin = request.get_header_value("Origin");
+    if (allowed_origins.empty() ||
+        std::find(allowed_origins.begin(), allowed_origins.end(), origin) !=
+            allowed_origins.end()) {
+      response.set_header("Access-Control-Allow-Origin", origin);
+      response.set_header("Vary", "Origin");
+    }
+  }
+  response.set_header("Access-Control-Allow-Methods",
+                      "GET, POST, DELETE, OPTIONS");
+  response.set_header("Access-Control-Allow-Headers",
+                      "Accept, Authorization, Content-Type, Last-Event-ID, "
+                      "MCP-Protocol-Version, Mcp-Method, Mcp-Name, "
+                      "Mcp-Session-Id");
+  response.set_header("Access-Control-Max-Age", "600");
+}
+
 core::Result<core::Unit> validate_host_header(
     const httplib::Request& request,
     const std::vector<std::string>& allowed_hosts) {
@@ -1046,6 +1067,29 @@ core::Result<core::Unit> HttpTransport::start(
     }
   }
 #endif  // defined(CXXMCP_ENABLE_AUTH)
+
+  http_server->Options(options_.path, [this](const httplib::Request& request,
+                                             httplib::Response& response) {
+    const auto host = validate_host_header(request, options_.allowed_hosts);
+    if (!host) {
+      response.status = host_failure_status(host.error());
+      write_error(response, host.error().code, host.error().message,
+                  std::nullopt);
+      return;
+    }
+
+    const auto origin =
+        validate_origin_header(request, options_.allowed_origins);
+    if (!origin) {
+      response.status = 400;
+      write_error(response, origin.error().code, origin.error().message,
+                  std::nullopt);
+      return;
+    }
+
+    set_cors_preflight_headers(request, response, options_.allowed_origins);
+    response.status = 204;
+  });
 
   http_server->Post(options_.path, [this, handler = std::move(handler),
                                     notification_handler =

--- a/tests/fixtures/process_stdio_child.mjs
+++ b/tests/fixtures/process_stdio_child.mjs
@@ -1,4 +1,5 @@
-import { McpServer, StdioServerTransport } from '@modelcontextprotocol/server';
+import { McpServer } from '@modelcontextprotocol/server';
+import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
 import * as z from 'zod/v4';
 
 const server = new McpServer({

--- a/tests/transport/test_http_transport.cpp
+++ b/tests/transport/test_http_transport.cpp
@@ -2971,6 +2971,122 @@ void test_server_http_transport_rejects_mismatched_origin_when_allowlisted() {
   server_transport.transport().stop();
 }
 
+void test_server_http_transport_handles_cors_preflight() {
+  constexpr int kPort = 40240;
+  const std::string kPath = "/mcp";
+
+  RunningServerTransportFixture server_transport(
+      std::make_unique<mcp::server::HttpTransport>(
+          mcp::server::HttpTransportOptions{
+              .listen_host = "127.0.0.1",
+              .listen_port = kPort,
+              .path = kPath,
+              .allowed_origins = {"https://inspector.example"},
+          }),
+      [](const mcp::protocol::JsonRpcRequest& request,
+         const mcp::server::SessionContext&) {
+        if (request.method == mcp::protocol::InitializeMethod) {
+          return mcp::protocol::JsonRpcResponse{
+              .id = request.id,
+              .result =
+                  Json{
+                      {"protocolVersion", mcp::protocol::McpProtocolVersion},
+                      {"capabilities", Json::object()},
+                      {"serverInfo",
+                       Json{{"name", "server-http-test"}, {"version", "1"}}},
+                  },
+          };
+        }
+        return mcp::protocol::make_error_response(
+            std::optional<mcp::protocol::RequestId>{request.id},
+            mcp::protocol::make_error(mcp::protocol::ErrorCode::MethodNotFound,
+                                      "unexpected request"));
+      });
+
+  require(!server_transport.start_error().has_value(),
+          "server transport should start");
+  require(wait_for_http_initialize(kPort, kPath),
+          "server transport should become reachable");
+
+  httplib::Client http_client("127.0.0.1", kPort);
+  const auto preflight =
+      http_client.Options(kPath,
+                          httplib::Headers{
+                              {"Origin", "https://inspector.example"},
+                              {"Access-Control-Request-Method", "POST"},
+                              {"Access-Control-Request-Headers",
+                               "content-type,mcp-session-id"},
+                          });
+  require(preflight != nullptr, "preflight should return a response");
+  require(preflight->status == 204, "preflight should succeed");
+  require(preflight->get_header_value("Access-Control-Allow-Origin") ==
+              "https://inspector.example",
+          "preflight should echo allowed origin");
+  require(preflight->get_header_value("Access-Control-Allow-Methods")
+              .find("POST") != std::string::npos,
+          "preflight should allow POST");
+  require(preflight->get_header_value("Access-Control-Allow-Methods")
+              .find("OPTIONS") != std::string::npos,
+          "preflight should allow OPTIONS");
+  require(preflight->get_header_value("Access-Control-Allow-Headers")
+              .find("Mcp-Session-Id") != std::string::npos,
+          "preflight should allow MCP session header");
+
+  server_transport.transport().stop();
+}
+
+void test_server_http_transport_rejects_disallowed_cors_preflight_origin() {
+  constexpr int kPort = 40241;
+  const std::string kPath = "/mcp";
+
+  RunningServerTransportFixture server_transport(
+      std::make_unique<mcp::server::HttpTransport>(
+          mcp::server::HttpTransportOptions{
+              .listen_host = "127.0.0.1",
+              .listen_port = kPort,
+              .path = kPath,
+              .allowed_origins = {"https://trusted.example"},
+          }),
+      [](const mcp::protocol::JsonRpcRequest& request,
+         const mcp::server::SessionContext&) {
+        if (request.method == mcp::protocol::InitializeMethod) {
+          return mcp::protocol::JsonRpcResponse{
+              .id = request.id,
+              .result =
+                  Json{
+                      {"protocolVersion", mcp::protocol::McpProtocolVersion},
+                      {"capabilities", Json::object()},
+                      {"serverInfo",
+                       Json{{"name", "server-http-test"}, {"version", "1"}}},
+                  },
+          };
+        }
+        return mcp::protocol::make_error_response(
+            std::optional<mcp::protocol::RequestId>{request.id},
+            mcp::protocol::make_error(mcp::protocol::ErrorCode::MethodNotFound,
+                                      "unexpected request"));
+      });
+
+  require(!server_transport.start_error().has_value(),
+          "server transport should start");
+  require(wait_for_http_initialize(kPort, kPath),
+          "server transport should become reachable");
+
+  httplib::Client http_client("127.0.0.1", kPort);
+  const auto preflight =
+      http_client.Options(kPath,
+                          httplib::Headers{
+                              {"Origin", "https://evil.example"},
+                              {"Access-Control-Request-Method", "POST"},
+                          });
+  require(preflight != nullptr,
+          "disallowed preflight should return a response");
+  require(preflight->status == 400,
+          "disallowed preflight origin should be rejected");
+
+  server_transport.transport().stop();
+}
+
 void test_server_http_transport_rejects_disallowed_host() {
   constexpr int kPort = 40235;
   const std::string kPath = "/mcp";
@@ -5925,6 +6041,10 @@ int main() {
        test_server_http_transport_authorized_request_sets_auth_identity},
       {"server http transport rejects mismatched origin when allowlisted",
        test_server_http_transport_rejects_mismatched_origin_when_allowlisted},
+      {"server http transport handles cors preflight",
+       test_server_http_transport_handles_cors_preflight},
+      {"server http transport rejects disallowed cors preflight origin",
+       test_server_http_transport_rejects_disallowed_cors_preflight_origin},
       {"server http transport rejects disallowed host",
        test_server_http_transport_rejects_disallowed_host},
       {"server http transport accepts standard post without custom headers",

--- a/tests/transport/test_http_transport.cpp
+++ b/tests/transport/test_http_transport.cpp
@@ -3009,27 +3009,26 @@ void test_server_http_transport_handles_cors_preflight() {
           "server transport should become reachable");
 
   httplib::Client http_client("127.0.0.1", kPort);
-  const auto preflight =
-      http_client.Options(kPath,
-                          httplib::Headers{
-                              {"Origin", "https://inspector.example"},
-                              {"Access-Control-Request-Method", "POST"},
-                              {"Access-Control-Request-Headers",
-                               "content-type,mcp-session-id"},
-                          });
+  const auto preflight = http_client.Options(
+      kPath, httplib::Headers{
+                 {"Origin", "https://inspector.example"},
+                 {"Access-Control-Request-Method", "POST"},
+                 {"Access-Control-Request-Headers",
+                  "content-type,mcp-session-id"},
+             });
   require(preflight != nullptr, "preflight should return a response");
   require(preflight->status == 204, "preflight should succeed");
   require(preflight->get_header_value("Access-Control-Allow-Origin") ==
               "https://inspector.example",
           "preflight should echo allowed origin");
-  require(preflight->get_header_value("Access-Control-Allow-Methods")
-              .find("POST") != std::string::npos,
+  require(preflight->get_header_value("Access-Control-Allow-Methods").find(
+              "POST") != std::string::npos,
           "preflight should allow POST");
-  require(preflight->get_header_value("Access-Control-Allow-Methods")
-              .find("OPTIONS") != std::string::npos,
+  require(preflight->get_header_value("Access-Control-Allow-Methods").find(
+              "OPTIONS") != std::string::npos,
           "preflight should allow OPTIONS");
-  require(preflight->get_header_value("Access-Control-Allow-Headers")
-              .find("Mcp-Session-Id") != std::string::npos,
+  require(preflight->get_header_value("Access-Control-Allow-Headers").find(
+              "Mcp-Session-Id") != std::string::npos,
           "preflight should allow MCP session header");
 
   server_transport.transport().stop();
@@ -3073,12 +3072,11 @@ void test_server_http_transport_rejects_disallowed_cors_preflight_origin() {
           "server transport should become reachable");
 
   httplib::Client http_client("127.0.0.1", kPort);
-  const auto preflight =
-      http_client.Options(kPath,
-                          httplib::Headers{
-                              {"Origin", "https://evil.example"},
-                              {"Access-Control-Request-Method", "POST"},
-                          });
+  const auto preflight = http_client.Options(
+      kPath, httplib::Headers{
+                 {"Origin", "https://evil.example"},
+                 {"Access-Control-Request-Method", "POST"},
+             });
   require(preflight != nullptr,
           "disallowed preflight should return a response");
   require(preflight->status == 400,

--- a/tests/transport/test_http_transport.cpp
+++ b/tests/transport/test_http_transport.cpp
@@ -3010,25 +3010,25 @@ void test_server_http_transport_handles_cors_preflight() {
 
   httplib::Client http_client("127.0.0.1", kPort);
   const auto preflight = http_client.Options(
-      kPath, httplib::Headers{
-                 {"Origin", "https://inspector.example"},
-                 {"Access-Control-Request-Method", "POST"},
-                 {"Access-Control-Request-Headers",
-                  "content-type,mcp-session-id"},
-             });
+      kPath,
+      httplib::Headers{
+          {"Origin", "https://inspector.example"},
+          {"Access-Control-Request-Method", "POST"},
+          {"Access-Control-Request-Headers", "content-type,mcp-session-id"},
+      });
   require(preflight != nullptr, "preflight should return a response");
   require(preflight->status == 204, "preflight should succeed");
   require(preflight->get_header_value("Access-Control-Allow-Origin") ==
               "https://inspector.example",
           "preflight should echo allowed origin");
-  require(preflight->get_header_value("Access-Control-Allow-Methods").find(
-              "POST") != std::string::npos,
+  require(preflight->get_header_value("Access-Control-Allow-Methods")
+                  .find("POST") != std::string::npos,
           "preflight should allow POST");
-  require(preflight->get_header_value("Access-Control-Allow-Methods").find(
-              "OPTIONS") != std::string::npos,
+  require(preflight->get_header_value("Access-Control-Allow-Methods")
+                  .find("OPTIONS") != std::string::npos,
           "preflight should allow OPTIONS");
-  require(preflight->get_header_value("Access-Control-Allow-Headers").find(
-              "Mcp-Session-Id") != std::string::npos,
+  require(preflight->get_header_value("Access-Control-Allow-Headers")
+                  .find("Mcp-Session-Id") != std::string::npos,
           "preflight should allow MCP session header");
 
   server_transport.transport().stop();
@@ -3072,11 +3072,11 @@ void test_server_http_transport_rejects_disallowed_cors_preflight_origin() {
           "server transport should become reachable");
 
   httplib::Client http_client("127.0.0.1", kPort);
-  const auto preflight = http_client.Options(
-      kPath, httplib::Headers{
-                 {"Origin", "https://evil.example"},
-                 {"Access-Control-Request-Method", "POST"},
-             });
+  const auto preflight =
+      http_client.Options(kPath, httplib::Headers{
+                                     {"Origin", "https://evil.example"},
+                                     {"Access-Control-Request-Method", "POST"},
+                                 });
   require(preflight != nullptr,
           "disallowed preflight should return a response");
   require(preflight->status == 400,


### PR DESCRIPTION
## Summary
- handle OPTIONS requests on the Streamable HTTP endpoint
- validate Host and Origin on preflight requests before returning CORS headers
- add regression coverage for accepted and rejected CORS preflight requests

Fixes #47

## Tests
- git diff --check
- cmake --build out/build/tests-mingw --target mcp_http_transport_tests
- ctest --test-dir out/build/tests-mingw -R "^http_transport$" --output-on-failure

Note: scripts\format.ps1 -Check could not run locally because clang-format is not installed in PATH.