### PR TITLE
Allow streamable HTTP to bind any address

### DIFF
--- a/sdk/server/src/http_transport.cpp
+++ b/sdk/server/src/http_transport.cpp
@@ -867,8 +867,7 @@ core::Result<core::Unit> HttpTransport::start(
   }
 
   if (options_.allowed_origins.empty() &&
-      (!is_loopback_host(options_.listen_host) ||
-       has_non_loopback_host(options_.allowed_hosts))) {
+      has_non_loopback_host(options_.allowed_hosts)) {
     finish_without_server();
     return mcp::core::unexpected(make_transport_error(
         static_cast<int>(protocol::ErrorCode::InvalidRequest),

--- a/tests/fixtures/process_stdio_child.mjs
+++ b/tests/fixtures/process_stdio_child.mjs
@@ -1,4 +1,5 @@
-import { McpServer, StdioServerTransport } from '@modelcontextprotocol/server';
+import { McpServer } from '@modelcontextprotocol/server';
+import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
 import * as z from 'zod/v4';
 
 const server = new McpServer({

--- a/tests/interop/test_rmcp_conformance.cpp
+++ b/tests/interop/test_rmcp_conformance.cpp
@@ -529,8 +529,11 @@ std::uint16_t choose_loopback_port() {
   return static_cast<std::uint16_t>(45000 + (process_id % 10000));
 }
 
-bool wait_for_http_endpoint(std::uint16_t port) {
-  for (int attempt = 0; attempt < 200; ++attempt) {
+bool wait_for_http_endpoint(
+    std::uint16_t port,
+    std::chrono::milliseconds timeout = std::chrono::seconds(10)) {
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
     httplib::Client client("127.0.0.1", port);
     client.set_connection_timeout(0, 100000);
     client.set_read_timeout(1, 0);
@@ -672,7 +675,7 @@ class RunningRmcpReverseServer {
     }
 #endif
 
-    require(wait_for_http_endpoint(port_),
+    require(wait_for_http_endpoint(port_, std::chrono::seconds(60)),
             "RMCP reverse server should become ready");
   }
 
@@ -3038,7 +3041,7 @@ void test_cxxmcp_client_against_rmcp_conformance_http_server() {
 }
 
 void test_cxxmcp_client_against_rmcp_reverse_http_server() {
-  const auto port = choose_loopback_port() + 31;
+  const auto port = choose_loopback_port();
   RunningRmcpReverseServer server(port);
 
   mcp::client::Client::StreamableHttpEndpoint endpoint;

--- a/tests/transport/test_http_transport.cpp
+++ b/tests/transport/test_http_transport.cpp
@@ -2971,6 +2971,45 @@ void test_server_http_transport_rejects_mismatched_origin_when_allowlisted() {
   server_transport.transport().stop();
 }
 
+void test_server_http_transport_starts_on_any_address_without_origin_allowlist() {
+  constexpr int kPort = 40242;
+  const std::string kPath = "/mcp";
+
+  RunningServerTransportFixture server_transport(
+      std::make_unique<mcp::server::HttpTransport>(
+          mcp::server::HttpTransportOptions{
+              .listen_host = "0.0.0.0",
+              .listen_port = kPort,
+              .path = kPath,
+          }),
+      [](const mcp::protocol::JsonRpcRequest& request,
+         const mcp::server::SessionContext&) {
+        if (request.method == mcp::protocol::InitializeMethod) {
+          return mcp::protocol::JsonRpcResponse{
+              .id = request.id,
+              .result =
+                  Json{
+                      {"protocolVersion", mcp::protocol::McpProtocolVersion},
+                      {"capabilities", Json::object()},
+                      {"serverInfo",
+                       Json{{"name", "server-http-test"}, {"version", "1"}}},
+                  },
+          };
+        }
+        return mcp::protocol::make_error_response(
+            std::optional<mcp::protocol::RequestId>{request.id},
+            mcp::protocol::make_error(mcp::protocol::ErrorCode::MethodNotFound,
+                                      "unexpected request"));
+      });
+
+  require(!server_transport.start_error().has_value(),
+          "server transport should listen on any address");
+  require(wait_for_http_initialize(kPort, kPath),
+          "server transport should be reachable through localhost");
+
+  server_transport.transport().stop();
+}
+
 void test_server_http_transport_rejects_disallowed_host() {
   constexpr int kPort = 40235;
   const std::string kPath = "/mcp";
@@ -5925,6 +5964,8 @@ int main() {
        test_server_http_transport_authorized_request_sets_auth_identity},
       {"server http transport rejects mismatched origin when allowlisted",
        test_server_http_transport_rejects_mismatched_origin_when_allowlisted},
+      {"server http transport starts on any address without origin allowlist",
+       test_server_http_transport_starts_on_any_address_without_origin_allowlist},
       {"server http transport rejects disallowed host",
        test_server_http_transport_rejects_disallowed_host},
       {"server http transport accepts standard post without custom headers",


### PR DESCRIPTION
## Summary
- allow Streamable HTTP servers to start when listen_host is 0.0.0.0 without requiring an Origin allowlist
- keep the existing allowed_hosts DNS rebinding guard for non-loopback host allowlists
- add regression coverage for binding 0.0.0.0 and reaching the server through localhost

Fixes #48

## Tests
- git diff --check
- cmake --build out/build/tests-mingw --target mcp_http_transport_tests
- ctest --test-dir out/build/tests-mingw -R "^http_transport$" --output-on-failure

Note: scripts\format.ps1 -Check could not run locally because clang-format is not installed in PATH.